### PR TITLE
Separate the Flatpak and AppImage configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ iOS
 android
 windows
 linux
+briefcase.*.log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,12 @@ requires=[
     'pygobject',
     'pillow',
 ]
+
+[tool.briefcase.app.testbed.linux.appimage]
+requires=[
+    '--no-binary', 'pillow'
+]
+
 system_requires = [
     # Required for GTK/PyGObject tests
     'gir1.2-gtk-3.0',
@@ -40,8 +46,17 @@ system_requires = [
     'libpng-dev',
     'libtiff-dev',
 ]
+
+linuxdeploy_plugins = [
+    'DEPLOY_GTK_VERSION=3 gtk',
+]
+
 support_package = "../Python-linux-support/dist/Python-3.10-linux-x86_64-support.custom.tar.gz"
 # template = "../../templates/briefcase-linux-appimage-template"
+
+[tool.briefcase.app.testbed.linux.flatpak]
+
+# template = "../../templates/briefcase-linux-flatpak-template"
 
 [tool.briefcase.app.testbed.windows]
 supported = false


### PR DESCRIPTION
* Adds a Flatpak configuration for Linux
* Separates the AppImage-specific configurations into a separate config section
* Forces AppImage installation of Pillow to be non-binary
* Adds the GTK plugin to the AppImage configuration

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
