### PR TITLE
Support dynamically loaded standard library builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ description = "A testbed for the Apple Support packages."
 icon = "src/testbed/resources/testbed"
 sources = ['src/testbed']
 requires = [
+    "lru_dict==1.1.6",
 ]
 
 [tool.briefcase.app.testbed.macOS]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,11 @@ description = "A testbed for the Apple Support packages."
 icon = "src/testbed/resources/testbed"
 sources = ['src/testbed']
 requires = [
+    "cryptography",
     "lru_dict",
     "pillow",
+    "numpy",
+    "pandas",
 ]
 
 [tool.briefcase.app.testbed.macOS]
@@ -22,7 +25,12 @@ requires = [
     "rubicon-objc",
     "std-nslog",
 ]
-support_package = "../Python-Apple-support/dist/Python-3.10-macOS-support.custom.tar.gz"
+# support_package = "../Python-Apple-support/dist/Python-3.8-macOS-support.custom.tar.gz"
+
+[tool.briefcase.app.testbed.macOS.app]
+# template = "../../templates/briefcase-macOS-app-template"
+
+[tool.briefcase.app.testbed.macOS.xcode]
 # template = "../../templates/briefcase-macOS-Xcode-template"
 
 [tool.briefcase.app.testbed.linux]
@@ -52,11 +60,10 @@ linuxdeploy_plugins = [
     'DEPLOY_GTK_VERSION=3 gtk',
 ]
 
-support_package = "../Python-linux-support/dist/Python-3.10-linux-x86_64-support.custom.tar.gz"
+# support_package = "../Python-linux-support/dist/Python-3.10-linux-x86_64-support.custom.tar.gz"
 # template = "../../templates/briefcase-linux-appimage-template"
 
 [tool.briefcase.app.testbed.linux.flatpak]
-
 # template = "../../templates/briefcase-linux-flatpak-template"
 
 [tool.briefcase.app.testbed.windows]
@@ -68,7 +75,7 @@ requires = [
     "rubicon-objc",
     "std-nslog",
 ]
-support_package = "../Python-Apple-support/dist/Python-3.10-iOS-support.custom.tar.gz"
+# support_package = "../Python-Apple-support/dist/Python-3.8-iOS-support.custom.tar.gz"
 # template = "../../templates/briefcase-iOS-Xcode-template"
 
 [tool.briefcase.app.testbed.android]
@@ -77,5 +84,5 @@ requires = [
     # Android doesn't provide the zoneinfo TZ database; use the Python provided one
     "tzdata",
 ]
-support_package = "../Python-Android-support/dist/Python-3.10-Android-support.custom.zip"
+# support_package = "../Python-Android-support/dist/Python-3.10-Android-support.custom.zip"
 # template = "../../templates/briefcase-Android-gradle-template"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ description = "A testbed for the Apple Support packages."
 icon = "src/testbed/resources/testbed"
 sources = ['src/testbed']
 requires = [
-    "lru_dict==1.1.6",
+    "lru_dict",
+    "pillow",
 ]
 
 [tool.briefcase.app.testbed.macOS]
@@ -28,7 +29,6 @@ support_package = "../Python-Apple-support/dist/Python-3.10-macOS-support.custom
 requires=[
     'pycairo',
     'pygobject',
-    'pillow',
 ]
 
 [tool.briefcase.app.testbed.linux.appimage]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,17 @@ linuxdeploy_plugins = [
 # template = "../../templates/briefcase-linux-flatpak-template"
 
 [tool.briefcase.app.testbed.windows]
-supported = false
+requires = [
+    "pythonnet>=3.0.0rc6",
+    # Windows doesn't provide the zoneinfo TZ database; use the Python provided one
+    "tzdata",
+]
+
+[tool.briefcase.app.testbed.windows.app]
+# template = "../../templates/briefcase-windows-app-template"
+
+[tool.briefcase.app.testbed.windows.VisualStudio]
+# template = "../../templates/briefcase-windows-VisualStudio-template"
 
 # Mobile deployments
 [tool.briefcase.app.testbed.iOS]

--- a/src/testbed/app.py
+++ b/src/testbed/app.py
@@ -6,7 +6,7 @@ import platform
 import sys
 import traceback
 
-from . import common, utils
+from . import common, thirdparty, utils
 
 
 def discover_tests(module):
@@ -37,6 +37,9 @@ def main():
         suite.extend(discover_tests(platform_module))
     except ModuleNotFoundError:
         print(f"No platform-specific tests for {sys.platform}")
+
+    # Add the tests for third-party modules.
+    suite.extend(discover_tests(thirdparty))
 
     # Run the suite
     failures = 0

--- a/src/testbed/common.py
+++ b/src/testbed/common.py
@@ -373,20 +373,3 @@ def test_zoneinfo():
 
     dt = datetime(2022, 5, 4, 13, 40, 42, tzinfo=ZoneInfo("Australia/Perth"))
     assert_(str(dt) == "2022-05-04 13:40:42+08:00")
-
-
-def test_lru_dict():
-    "The LRUDict binary module can be used"
-    from lru import LRU
-    lru_dict = LRU(5)
-
-    # Add 10 items
-    for i in range(10):
-        lru_dict[f"item_{i}"] = i
-
-    # Items 0-4 have been evicted
-    for i in range(5):
-        assert_(f"item_{i}" not in lru_dict)
-    # Items 5-9 are still there
-    for i in range(5, 10):
-        assert_(lru_dict[f"item_{i}"] == i)

--- a/src/testbed/common.py
+++ b/src/testbed/common.py
@@ -12,9 +12,7 @@ from .utils import assert_, skipIf
 def test_bootstrap_modules():
     "All the bootstrap modules are importable"
     missing = []
-
-    # The list of bootstrap modules that don't have explicit tests.
-    for module in [
+    all_modules = [
         '_abc',
         '_codecs',
         '_collections',
@@ -36,7 +34,14 @@ def test_bootstrap_modules():
         'posix',
         'pwd',
         'time',
-    ]:
+    ]
+
+    # Modules that are disabled on iOS
+    if sys.platform == "ios":
+        all_modules.remove('pwd')
+
+    # The list of bootstrap modules that don't have explicit tests.
+    for module in all_modules:
         try:
             importlib.import_module(module)
         except ModuleNotFoundError:
@@ -97,10 +102,17 @@ def test_stdlib_modules():
     if sys.version_info >= (3, 11):
         all_modules.extend(['_typing'])
 
-    # Modules that are known to not exist on Android
+    # Modules that do not exist on Android
     if hasattr(sys, 'getandroidapilevel'):
         all_modules.remove('grp')
         all_modules.remove('_crypt')
+
+    # Modules that do not exist on iOS
+    if sys.platform == 'ios':
+        all_modules.remove("_multiprocessing")
+        all_modules.remove("_posixsubprocess")
+        all_modules.remove("grp")
+        all_modules.remove("syslog")
 
     # Modules that are shadows of pure python modules, but should be compiled
     all_modules.extend([

--- a/src/testbed/common.py
+++ b/src/testbed/common.py
@@ -2,7 +2,6 @@
 # Common tests
 ###########################################################################
 import importlib
-import os
 import sys
 
 
@@ -39,6 +38,11 @@ def test_bootstrap_modules():
     # Modules that are disabled on iOS
     if sys.platform == "ios":
         all_modules.remove('pwd')
+
+    # Modules that are disabled on Windows
+    if sys.platform == "win32":
+        all_modules.remove("posix")
+        all_modules.remove("pwd")
 
     # The list of bootstrap modules that don't have explicit tests.
     for module in all_modules:
@@ -114,6 +118,16 @@ def test_stdlib_modules():
         all_modules.remove("grp")
         all_modules.remove("syslog")
 
+    # Modules that do not exist on Windows
+    if sys.platform == "win32":
+        all_modules.remove("_crypt")
+        all_modules.remove("_posixsubprocess")
+        all_modules.remove("fcntl")
+        all_modules.remove("grp")
+        all_modules.remove("resource")
+        all_modules.remove("syslog")
+        all_modules.remove("termios")
+
     # Modules that are shadows of pure python modules, but should be compiled
     all_modules.extend([
         "_elementtree",
@@ -165,6 +179,8 @@ def test_dbm_dumb():
 
 
 @skipIf(hasattr(sys, 'getandroidapilevel'), "NDBM not available on Android")
+@skipIf(sys.platform == "linux", "NDBM not universally available on Linux")
+@skipIf(sys.platform == "win32", "NDBM not available on Windows")
 def test_dbm_ndbm():
     "The ndbm DBM module has been compiled and works"
     from dbm import ndbm

--- a/src/testbed/common.py
+++ b/src/testbed/common.py
@@ -373,3 +373,20 @@ def test_zoneinfo():
 
     dt = datetime(2022, 5, 4, 13, 40, 42, tzinfo=ZoneInfo("Australia/Perth"))
     assert_(str(dt) == "2022-05-04 13:40:42+08:00")
+
+
+def test_lru_dict():
+    "The LRUDict binary module can be used"
+    from lru import LRU
+    lru_dict = LRU(5)
+
+    # Add 10 items
+    for i in range(10):
+        lru_dict[f"item_{i}"] = i
+
+    # Items 0-4 have been evicted
+    for i in range(5):
+        assert_(f"item_{i}" not in lru_dict)
+    # Items 5-9 are still there
+    for i in range(5, 10):
+        assert_(lru_dict[f"item_{i}"] == i)

--- a/src/testbed/linux.py
+++ b/src/testbed/linux.py
@@ -87,18 +87,3 @@ def test_cairo():
 
     surface = cairo.ImageSurface(cairo.Format.ARGB32, 100, 200)
     assert_(surface.get_width() == 100)
-
-
-def test_pillow():
-    "Pillow can be used to load images"
-    from PIL import Image
-
-    for extension in ['png', 'jpg']:
-        image = Image.open(
-            os.path.join(
-                os.path.dirname(__file__),
-                "resources",
-                f"test-pattern.{extension}"
-            )
-        )
-        assert_(image.size == (1366, 768))

--- a/src/testbed/thirdparty.py
+++ b/src/testbed/thirdparty.py
@@ -2,13 +2,16 @@
 # Tests of third-party modules
 ###########################################################################
 import os
+import sys
 
-from .utils import assert_
+from .utils import assert_, skipIf
 
 
+@skipIf(sys.platform == "win32", "cffi not available on windows")
 def test_cffi():
     "CFFI can be used as an alternative FFI interface"
     from cffi import FFI
+
     ffi = FFI()
     ffi.cdef("size_t strlen(char *str);")
     lib = ffi.dlopen(None)
@@ -115,11 +118,12 @@ def test_pandas():
     # Another high profile package, with a dependency on numpy
     df = DataFrame([("alpha", 1), ("bravo", 2), ("charlie", 3)],
                     columns=["Letter", "Number"])
+
     assert_(
         (
             ",Letter,Number\n"
             "0,alpha,1\n"
             "1,bravo,2\n"
             "2,charlie,3\n"
-        ) == df.to_csv()
+        ) == df.to_csv(lineterminator="\n")
     )

--- a/src/testbed/thirdparty.py
+++ b/src/testbed/thirdparty.py
@@ -1,0 +1,38 @@
+###########################################################################
+# Tests of third-party modules
+###########################################################################
+import os
+
+from .utils import assert_
+
+
+def test_lru_dict():
+    "The LRUDict binary module can be used"
+    from lru import LRU
+    lru_dict = LRU(5)
+
+    # Add 10 items
+    for i in range(10):
+        lru_dict[f"item_{i}"] = i
+
+    # Items 0-4 have been evicted
+    for i in range(5):
+        assert_(f"item_{i}" not in lru_dict)
+    # Items 5-9 are still there
+    for i in range(5, 10):
+        assert_(lru_dict[f"item_{i}"] == i)
+
+
+def test_pillow():
+    "Pillow can be used to load images"
+    from PIL import Image
+
+    for extension in ['png', 'jpg']:
+        image = Image.open(
+            os.path.join(
+                os.path.dirname(__file__),
+                "resources",
+                f"test-pattern.{extension}"
+            )
+        )
+        assert_(image.size == (1366, 768))

--- a/src/testbed/thirdparty.py
+++ b/src/testbed/thirdparty.py
@@ -6,8 +6,71 @@ import os
 from .utils import assert_
 
 
+def test_cffi():
+    "CFFI can be used as an alternative FFI interface"
+    from cffi import FFI
+    ffi = FFI()
+    ffi.cdef("size_t strlen(char *str);")
+    lib = ffi.dlopen(None)
+    assert_(lib.strlen(ffi.new("char[]", b"hello world")) == 11)
+
+
+def test_cryptography():
+    "The cryptography module can be used"
+    # Cryptography is a common binary library that uses cffi and OpenSSL (1.1.1) internally
+    from cryptography.fernet import Fernet
+    from cryptography.hazmat.backends import default_backend
+    from cryptography import x509
+    from cryptography.x509.oid import NameOID
+    from textwrap import dedent
+
+    # Encrypt a message with Fernet
+    key = Fernet.generate_key()
+    f = Fernet(key)
+    msg = b"my deep dark secret"
+    token = f.encrypt(msg)
+    assert_(msg == f.decrypt(token))
+
+    # Decode an x509 certificate
+    cert_pem = dedent("""
+        -----BEGIN CERTIFICATE-----
+        MIIEhDCCA2ygAwIBAgIIF2d9E030vlcwDQYJKoZIhvcNAQELBQAwVDELMAkGA1UE
+        BhMCVVMxHjAcBgNVBAoTFUdvb2dsZSBUcnVzdCBTZXJ2aWNlczElMCMGA1UEAxMc
+        R29vZ2xlIEludGVybmV0IEF1dGhvcml0eSBHMzAeFw0xODA0MTcxMzI0MzhaFw0x
+        ODA3MTAxMjM5MDBaMGkxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlh
+        MRYwFAYDVQQHDA1Nb3VudGFpbiBWaWV3MRMwEQYDVQQKDApHb29nbGUgSW5jMRgw
+        FgYDVQQDDA93d3cuYW5kcm9pZC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
+        ggEKAoIBAQC3t8zd3s9oSLFUkogYhD//BoFwvtHnpUHW2n9g3KiAXCHHG5+8QD4Q
+        abgAzrpeQqewWngE9B3Feq4rUo9vsk0UpB7Pj97TAgkkmpRMcW0lU4p4rKNhDfri
+        c+SvnuZuy048v8Ta7DtMymuCIyejekjTg7Gf/U46PqK87ZbV5RTadSgfvlymnkQb
+        SwJLUA8qe/H98bEARpQLyJvWi8dUSurpfKHdbXfd1Dk9GACHNAX9A4bV0BdQBmPu
+        6BMGeY5O4CYwwM51U/W+ptyc5eFRMi10up1cck3Udwl/jw5OAx5NP7geuxuIc4uu
+        l41Zwbnr5v6sdJJsWMvMg7ot/97+EHvXAgMBAAGjggFDMIIBPzATBgNVHSUEDDAK
+        BggrBgEFBQcDATAaBgNVHREEEzARgg93d3cuYW5kcm9pZC5jb20waAYIKwYBBQUH
+        AQEEXDBaMC0GCCsGAQUFBzAChiFodHRwOi8vcGtpLmdvb2cvZ3NyMi9HVFNHSUFH
+        My5jcnQwKQYIKwYBBQUHMAGGHWh0dHA6Ly9vY3NwLnBraS5nb29nL0dUU0dJQUcz
+        MB0GA1UdDgQWBBSYOxV7LRH/9yKSFL5jLJfhwZxCUDAMBgNVHRMBAf8EAjAAMB8G
+        A1UdIwQYMBaAFHfCuFCaZ3Z2sS3ChtCDoH6mfrpLMCEGA1UdIAQaMBgwDAYKKwYB
+        BAHWeQIFAzAIBgZngQwBAgIwMQYDVR0fBCowKDAmoCSgIoYgaHR0cDovL2NybC5w
+        a2kuZ29vZy9HVFNHSUFHMy5jcmwwDQYJKoZIhvcNAQELBQADggEBAI4fv5P+VLSE
+        /f+hOoPuxWx2TEDdc/Gt2u3XUiGkMrOSW2k1ob0kUjBDILhear3tpp+V5N5H0NzZ
+        Ymvpbbl3ZD5Bk5Co9FIJwFNMfGAlzSAduuYdAblOXTkLzlyLwn5qbzDjbkBIS+0O
+        l+1zga+3gZGYbDQiByFyq8P/uAKzc0BAX82bgXDkIC3E26YvvTnUpkKh6l6bOOTB
+        xaTg8Uh6KsKGch837BDbNegs3wHw3T3s7PC+H7dvqjELqN7y2GNNA361/aPPCWgs
+        jUsy3XnYSd8og34IzY3+W2b3TrU8P+p+pBwOjgXuNHZwobU+3/e2s4/0AfDilpI0
+        KX/1hroho1I=
+        -----END CERTIFICATE-----
+    """).encode("ASCII")
+
+    cert = x509.load_pem_x509_certificate(cert_pem, default_backend())
+    domain = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+    assert_("www.android.com" == domain)
+
+
 def test_lru_dict():
     "The LRUDict binary module can be used"
+    # lru-dict is the simplest possible example of a third-party module.
+    # It is pure C, built using distutils, with no dependencies.
     from lru import LRU
     lru_dict = LRU(5)
 
@@ -25,6 +88,7 @@ def test_lru_dict():
 
 def test_pillow():
     "Pillow can be used to load images"
+    # Pillow is a module that has dependencies on other libraries (libjpeg, libft2)
     from PIL import Image
 
     for extension in ['png', 'jpg']:
@@ -36,3 +100,26 @@ def test_pillow():
             )
         )
         assert_(image.size == (1366, 768))
+
+
+def test_numpy():
+    "Numpy Arrays can be created"
+    from numpy import array
+    # Numpy is the thousand pound gorilla packaging test.
+    assert_([4, 7] == (array([1, 2]) + array([3, 5])).tolist())
+
+
+def test_pandas():
+    "Pandas DataFrames can be created"
+    from pandas import DataFrame
+    # Another high profile package, with a dependency on numpy
+    df = DataFrame([("alpha", 1), ("bravo", 2), ("charlie", 3)],
+                    columns=["Letter", "Number"])
+    assert_(
+        (
+            ",Letter,Number\n"
+            "0,alpha,1\n"
+            "1,bravo,2\n"
+            "2,charlie,3\n"
+        ) == df.to_csv()
+    )

--- a/src/testbed/win32.py
+++ b/src/testbed/win32.py
@@ -1,0 +1,24 @@
+###########################################################################
+# Linux specific tests
+###########################################################################
+import os
+import sys
+
+from .utils import assert_
+
+
+def exit(failures):
+    sys.exit(failures)
+
+
+def test_pythonnet():
+    "Python.net integration works as expected"
+    # Set up CLR
+    import clr
+    clr.AddReference("System.Windows.Forms")
+
+    # Now use CLR libraries
+    from System.Drawing import Image
+
+    image = Image.FromFile(os.path.join(os.path.dirname(__file__), "resources", "test-pattern.png"))
+    assert_((image.Size.Width, image.Size.Height) == (1366, 768))


### PR DESCRIPTION
The move to a dynamically loaded standard library (beeware/Python-Apple-support#161) requires some changes to the testbed:

* Removes some modules from the bootstrap and expected standard libraries
* Adds a test of the `lru-dict` module as a minimal test of binary packages
* Adds a test of `cffi`, `cryptography`, `numpy` and `pandas` as more detailed binary packaging tests.
* Adds a test of the Windows backend.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
