### PR TITLE
Add directives to install rustc for Linux AppImages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,20 @@ system_requires = [
     'libjpeg-dev',
     'libpng-dev',
     'libtiff-dev',
+    # Required to install Rust
+    'curl',
+    'libssl-dev',
 ]
 
 linuxdeploy_plugins = [
     'DEPLOY_GTK_VERSION=3 gtk',
 ]
+
+dockerfile_extra_content = """
+# Install Rust (required for cryptography)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/home/brutus/.cargo/bin:${PATH}"
+"""
 
 # support_package = "../Python-linux-support/dist/Python-3.10-linux-x86_64-support.custom.tar.gz"
 # template = "../../templates/briefcase-linux-appimage-template"


### PR DESCRIPTION
When packaging for Linux AppImage, all binary packages are installed form source; however more recent versions of cryptography require a rust compiler toolchain. This can't be installed with `apt-get`; it requires a custom installation script.

Refs beeware/briefcase-linux-appimage-template#22

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
