### PR TITLE
Add test for utf-8 encoding of stdout/err

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,9 @@ jobs:
     - name: Package
       run: |
         briefcase package ${{ matrix.briefcase-target }} --update --adhoc-sign
+    - uses: actions/upload-artifact@v3
+      name: Upload logs
+      if: failure()
+      with:
+        name: build-failure-logs-${{ matrix.backend }}-${{ matrix.python-version }}
+        path: logs/*

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,6 +2,7 @@
 # Common tests
 ###########################################################################
 import importlib
+import locale
 import sys
 
 import pytest
@@ -324,6 +325,33 @@ def test_tempfile():
         # Reset the file pointer to 0 and read back the content
         f.seek(0)
         assert f.read() == msg
+
+
+def test_utf8_encoding():
+    "The Python interpreter is pre-configured with the correct encoding"
+
+    # The default locale is UTF-8
+    assert locale.getpreferredencoding(False).lower() == "utf-8"
+
+    # Confirm that sys.stdout and sys.stderr have UTF encoding.
+    # utf-8 is the encoding for systems that write directly to console;
+    # utf-16-le/be will be the encoding when std-nslog is being used.
+    assert sys.stdout.encoding.lower() in {"utf-8", "utf-16-le", "utf-16-be"}
+    assert sys.stderr.encoding.lower() in {"utf-8", "utf-16-le", "utf-16-be"}
+
+    # Print some actual content to the *original* stdout/stderr
+    # file handles. On success, this content will be swallowed by the
+    # test runner; however, if the encoding isn't correct, the print
+    # statement will raise a UnicodeEncodeError. On success, no error
+    # will be raised.
+    try:
+        print("Hëllø worłd 你好世界 (stdout)", file=sys.__stdout__)
+    except UnicodeEncodeError:
+        pytest.fail("stdout does not have the correct encoding")
+    try:
+        print("Hëllø worłd 你好世界 (stderr)", file=sys.__stderr__)
+    except UnicodeEncodeError:
+        pytest.fail("stderr does not have the correct encoding")
 
 
 def test_uuid():

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -53,8 +53,8 @@ def test_gdk():
     gi.require_version("Gdk", "3.0")
     from gi.repository import Gdk
 
-    color = Gdk.Color(37, 42, 69)
-    assert color.to_string() == "#0025002a0045"
+    color = Gdk.RGBA(0.37, 0.42, 0.69, 0.5)
+    assert color.to_string() == "rgba(94,107,176,0.5)"
 
 
 def test_gtk():


### PR DESCRIPTION
beeware/briefcase-macOS-Xcode-template#18 identified that macOS apps weren't being started with the correct system encoding. This PR adds a test case to verify this encoding.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
