### PR TITLE
Remove Android test discovery workarounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,11 +109,6 @@ requires = [
     "tzdata",
 ]
 
-# TODO: replace with extractPackages
-build_gradle_extra_content = """
-android.defaultConfig.python.pyc.src false
-"""
-
 # support_package = "../Python-Android-support/dist/Python-3.10-Android-support.custom.zip"
 # template = "../../templates/briefcase-Android-gradle-template"
 

--- a/tests/testbed.py
+++ b/tests/testbed.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import tempfile
 from pathlib import Path
 
@@ -9,30 +8,6 @@ import pytest
 def run_tests():
     project_path = Path(__file__).parent.parent
     os.chdir(Path(__file__).parent.parent)
-
-    ##################################################################
-    # WORKAROUND - On Android, we need to explicitly unpack the test
-    # source code into a location where it can be discovered.
-    ##################################################################
-    if hasattr(sys, "getandroidapilevel"):
-        import tests
-
-        def chaquopy_extract_package(pkg):
-            finder = pkg.__loader__.finder
-            for path in pkg.__path__:
-                chaquopy_extract_dir(finder, finder.zip_path(path))
-
-        def chaquopy_extract_dir(finder, zip_dir):
-            for filename in finder.listdir(zip_dir):
-                zip_path = f"{zip_dir}/{filename}"
-                if finder.isdir(zip_path):
-                    chaquopy_extract_dir(finder, zip_path)
-                else:
-                    finder.extract_if_changed(zip_path)
-
-        chaquopy_extract_package(tests)
-    ##################################################################
-
     returncode = pytest.main(
         [
             # Turn up verbosity


### PR DESCRIPTION
They're no longer needed now that `extractPackages` is in the Android template.

Requires https://github.com/beeware/briefcase-android-gradle-template/pull/60: DO NOT MERGE this PR before that one.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
