### PR TITLE
Bump pyupgrade from v3.10.1 to v3.11.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: isort
         additional_dependencies: [toml]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
+    rev: v3.11.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]


### PR DESCRIPTION
Bumps `pre-commit` hook for `pyupgrade` from v3.10.1 to v3.11.0 and ran the update against the repo.