### PR TITLE
Bump isort from 5.13.0 to 5.13.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.0
+    rev: 5.13.2
     hooks:
       - id: isort
         additional_dependencies: [toml]


### PR DESCRIPTION
Bumps `pre-commit` hook for `isort` from 5.13.0 to 5.13.2 and ran the update against the repo.