### PR TITLE
Upgrade `upload-artifact` action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,17 @@ on:
       - main
   workflow_call:
 
+# Cancel active CI runs for a PR before starting another run
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
-    shell: bash  # https://github.com/beeware/briefcase/pull/912
+    shell: bash
+
+env:
+  FORCE_COLOR: "1"
 
 jobs:
   pre-commit:
@@ -55,17 +63,17 @@ jobs:
           - backend: linux-system
             runs-on: ubuntu-latest
             python-version: "system"
-            pre-command: "sudo apt-get update -y && sudo apt-get install -y python3-gi python3-gi-cairo gir1.2-gtk-3.0 python3-dev libgirepository1.0-dev libcairo2-dev pkg-config"
+            pre-command: "sudo apt update -y && sudo apt install -y --no-install-recommends python3-dev python3-pip libcairo2-dev libgirepository1.0-dev gir1.2-gtk-3.0"
             briefcase-target: "linux system"
 
           # - backend: linux-appimage
           #   runs-on: ubuntu-latest
-          #   pre-command: "sudo apt-get update -y && sudo apt-get install -y python3-gi python3-gi-cairo gir1.2-gtk-3.0 python3-dev libgirepository1.0-dev libcairo2-dev pkg-config libfuse2"
+          #   pre-command: "sudo apt update -y && sudo apt install -y --no-install-recommends libfuse2 libthai-dev libegl1"
           #   briefcase-target: "linux appimage"
 
           - backend: linux-flatpak
             runs-on: ubuntu-latest
-            pre-command: "sudo apt-get update -y && sudo apt-get install -y python3-gi python3-gi-cairo gir1.2-gtk-3.0 python3-dev libgirepository1.0-dev libcairo2-dev pkg-config flatpak flatpak-builder"
+            pre-command: "sudo apt update -y && sudo apt install -y --no-install-recommends flatpak flatpak-builder elfutils"
             briefcase-target: "linux flatpak"
 
           - backend: windows-VisualStudio
@@ -94,12 +102,9 @@ jobs:
           - backend: "android"
             python-version: "3.12"
 
-            # Support packages for Flatpak aren't available for 3.12+ on Linux yet
-          - backend: "linux-flatpak"
-            python-version: "3.12"
-
     steps:
-    - uses: actions/checkout@v4.1.1
+    - name: Checkout
+      uses: actions/checkout@v4.1.1
       with:
         fetch-depth: 0
 
@@ -109,7 +114,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
+    - name: Install Dependencies
       run: ${{ matrix.pre-command }}
 
     - name: Install Briefcase
@@ -121,8 +126,8 @@ jobs:
     - name: Package
       run: briefcase package ${{ matrix.briefcase-target }} --update --adhoc-sign
 
-    - name: Upload logs
-      uses: actions/upload-artifact@v3.1.3
+    - name: Upload Logs
+      uses: actions/upload-artifact@v4.0.0
       if: failure()
       with:
         name: build-failure-logs-${{ matrix.backend }}-${{ matrix.python-version }}


### PR DESCRIPTION
## Changes
- RE: https://github.com/beeware/.github/issues/77
- `upload-artifact` can be upgraded without other changes since it already only creates unique artifacts
- Also:
  - Slimmed down the install requirements for linux builds
  - Enabled testing for Flatpak with Python 3.12

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
