### PR TITLE
Bump flake8 from 6.1.0 to 7.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,6 @@ repos:
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: flake8


### PR DESCRIPTION
Bumps `pre-commit` hook for `flake8` from 6.1.0 to 7.0.0 and ran the update against the repo.