### PR TITLE
Bump black-pre-commit-mirror from 24.3.0 to 24.4.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.3.0
+    rev: 24.4.0
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ requires = [
     "lru_dict",
     "pillow",
     "numpy",
-    "pandas",
+    # Pandas 2.2.2 doesn't publish ARM64 macOS wheels for Py 3.9 or 3.10
+    "pandas != 2.2.2; python_version < '3.11'",
+    "pandas; python_version >= '3.11'"
 ]
 test_requires = [
     "pytest",


### PR DESCRIPTION
Bumps `pre-commit` hook for `black-pre-commit-mirror` from 24.3.0 to 24.4.0 and ran the update against the repo.