### PR TITLE
Bump flatpak base image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,53 +66,6 @@ system_runtime_requires = [
     "libcanberra-gtk3-module",
 ]
 
-[tool.briefcase.app.testbed.linux.appimage]
-manylinux = "manylinux_2_28"
-requires = [
-    '--no-binary', ':all:',
-]
-
-system_requires = [
-    # Needed to compile pycairo wheel
-    "cairo-gobject-devel",
-    # Needed to compile PyGObject wheel
-    "gobject-introspection-devel",
-    # Needed to provide GTK
-    "gtk3-devel",
-    # Dependencies that GTK looks for at runtime, that need to be
-    # in the build environment to be picked up by linuxdeploy
-    "libcanberra-gtk3",
-    "PackageKit-gtk3-module",
-    "gvfs-client",
-    # Needed to compile Pillow
-    "libjpeg-devel",
-    # Needed to compile Cryptography
-    "openssl-devel",
-]
-
-linuxdeploy_plugins = [
-    'DEPLOY_GTK_VERSION=3 gtk',
-]
-
-dockerfile_extra_content = """
-# Install Rust (required for cryptography)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-# Set up compilers (required for numpy)
-ENV CXX="g++ -pthread"
-ENV AR=ar
-# Add a symlink for python->python3 (needed for pandas)
-# Pandas *requires* that the Python binary be called `python`, not `python3`.
-# However, Python-standalone *only* provides `python3`, and at runtime, we
-# only need `python3`. We can't (easily) reconfigure the Meson build for Pandas,
-# so we put a symlink in `brutus`'s bin path.
-RUN mkdir -p /home/brutus/bin
-RUN ln -si /app/Testbed.AppDir/usr/python/bin/python3 /home/brutus/bin/python
-# Set the path to include all the things we've installed.
-ENV PATH="/home/brutus/bin:/home/brutus/.cargo/bin:${PATH}"
-"""
-
-# template = "../../templates/briefcase-linux-appimage-template"
-
 [tool.briefcase.app.testbed.linux.flatpak]
 flatpak_runtime = "org.gnome.Platform"
 flatpak_runtime_version = "45"
@@ -144,7 +97,6 @@ requires = [
 
 [tool.briefcase.app.testbed.android]
 requires = [
-    "rubicon-java",
     # Android doesn't provide the zoneinfo TZ database; use the Python provided one
     "tzdata",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,12 +111,11 @@ RUN ln -si /app/Testbed.AppDir/usr/python/bin/python3 /home/brutus/bin/python
 ENV PATH="/home/brutus/bin:/home/brutus/.cargo/bin:${PATH}"
 """
 
-# support_package = "../Python-linux-support/dist/Python-3.10-linux-x86_64-support.custom.tar.gz"
 # template = "../../templates/briefcase-linux-appimage-template"
 
 [tool.briefcase.app.testbed.linux.flatpak]
 flatpak_runtime = "org.gnome.Platform"
-flatpak_runtime_version = "44"
+flatpak_runtime_version = "45"
 flatpak_sdk = "org.gnome.Sdk"
 
 # template = "../../templates/briefcase-linux-flatpak-template"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -96,7 +96,6 @@ def test_stdlib_modules():
         "termios",
         "unicodedata",
         # Scheduled for deprecation
-        "_crypt",
         "audioop",
     ]
 
@@ -110,7 +109,6 @@ def test_stdlib_modules():
     # Modules that do not exist on Android
     if hasattr(sys, "getandroidapilevel"):
         all_modules.remove("grp")
-        all_modules.remove("_crypt")
 
     # Modules that do not exist on iOS
     if sys.platform == "ios":
@@ -121,7 +119,6 @@ def test_stdlib_modules():
 
     # Modules that do not exist on Windows
     if sys.platform == "win32":
-        all_modules.remove("_crypt")
         all_modules.remove("_posixsubprocess")
         all_modules.remove("fcntl")
         all_modules.remove("grp")


### PR DESCRIPTION
Upgrades the base Flatpak image to Gnome v45 (v44 is now deprecated).

The v45 base no longer contains `libcrypto.so.0`; as this library is only needed for the `crypt` library test, and that library has been removed in Python 3.13, validation of `crypt` has been removed from the stdlib test.

Fixes #76.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
