### PR TITLE
Add initial support for Python3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ requires = [
     "cryptography",
     "lru_dict",
     "pillow",
-    # Numpy/pandas aren't available for iOS on 3.13+.
-    "numpy; python_version < '3.13' or platform_system != 'iOS'",
-    "pandas; python_version < '3.13' or platform_system != 'iOS'",
+    # Numpy/pandas aren't available for iOS on 3.13+, or at all on 3.14.
+    "numpy; python_version < '3.13' or (platform_system != 'iOS' and python_version < '3.14')",
+    "pandas; python_version < '3.13' or (platform_system != 'iOS' and python_version < '3.14')",
 ]
 test_requires = [
     "pytest",
@@ -37,7 +37,7 @@ requires = [
     "rubicon-objc",
     "std-nslog",
 ]
-# support_package = "../Python-Apple-support/dist/Python-3.13-macOS-support.custom.tar.gz"
+# support_package = "../Python-Apple-support/dist/Python-3.14-macOS-support.custom.tar.gz"
 
 [tool.briefcase.app.testbed.macOS.app]
 # template = "../../templates/briefcase-macOS-app-template"
@@ -77,8 +77,8 @@ flatpak_sdk = "org.gnome.Sdk"
 
 [tool.briefcase.app.testbed.windows]
 requires = [
-    # Python.net isn't avaialble for 3.13 yet.
-    "pythonnet>=3.0.0rc6; python_version < '3.13'",
+    # Python.net isn't avaialble for 3.14 yet.
+    "pythonnet>=3.0.0rc6; python_version < '3.14'",
     # Windows doesn't provide the zoneinfo TZ database; use the Python provided one
     "tzdata",
 ]
@@ -95,7 +95,7 @@ requires = [
     "rubicon-objc",
     "std-nslog",
 ]
-# support_package = "../Python-Apple-support/dist/Python-3.13-iOS-support.custom.tar.gz"
+# support_package = "../Python-Apple-support/dist/Python-3.14-iOS-support.custom.tar.gz"
 # template = "../../templates/briefcase-iOS-Xcode-template"
 
 [tool.briefcase.app.testbed.android]
@@ -110,7 +110,7 @@ build_gradle_dependencies = [
     "com.google.android.material:material:1.11.0",
 ]
 
-# support_package = "../Python-Android-support/dist/Python-3.13-Android-support.custom.zip"
+# support_package = "../Python-Android-support/dist/Python-3.14-Android-support.custom.zip"
 # template = "../../templates/briefcase-Android-gradle-template"
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ flatpak_sdk = "org.gnome.Sdk"
 [tool.briefcase.app.testbed.windows]
 requires = [
     # Python.net isn't avaialble for 3.14 yet.
-    "pythonnet>=3.0.0rc6; python_version < '3.14'",
+    "pythonnet>=3.0.0; python_version < '3.14'",
     # Windows doesn't provide the zoneinfo TZ database; use the Python provided one
     "tzdata",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,8 +110,7 @@ build_gradle_dependencies = [
     "com.google.android.material:material:1.11.0",
 ]
 
-# support_package = "../Python-Android-support/dist/Python-3.14-Android-support.custom.zip"
-# template = "../../templates/briefcase-Android-gradle-template"
+# template = "../../templates/briefcase-android-gradle-template"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Adds initial support for Python 3.14, in the form of widening the version exclusions for installing numpy, pandas and Pythonnet.

We can't add CI coverage for 3.14 yet because there's no published support packages or stubs. But we can't publish support packages until this project can be built under Python 3.14, as this project is used by CI on the support package builds.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
