### PR TITLE
Add dependency exclusions for iOS and Android on 3.14.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,9 @@ test_sources = ["tests"]
 
 requires = [
     # Skip binary dependencies on mobile for Python 3.14
-    "cryptography; not (platform_system == 'iOS' or platform_system == 'Android') or python_version < '3.14')",
-    "lru_dict; not (platform_system == 'iOS' or platform_system == 'Android') or python_version < '3.14')",
-    "pillow; not (platform_system == 'iOS' or platform_system == 'Android') or python_version < '3.14')",
+    "cryptography; (platform_system != 'iOS' and platform_system != 'Android') or python_version < '3.14'",
+    "lru_dict; (platform_system != 'iOS' and platform_system != 'Android') or python_version < '3.14'",
+    "pillow; (platform_system != 'iOS' and platform_system != 'Android') or python_version < '3.14'",
     # Numpy/pandas aren't available for iOS on 3.13+, or at all on 3.14.
     "numpy; python_version < '3.13' or (platform_system != 'iOS' and python_version < '3.14')",
     "pandas; python_version < '3.13' or (platform_system != 'iOS' and python_version < '3.14')",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,10 @@ sources = ["src/testbed"]
 test_sources = ["tests"]
 
 requires = [
-    "cryptography",
-    "lru_dict",
-    "pillow",
+    # Skip binary dependencies on mobile for Python 3.14
+    "cryptography; not (platform_system == 'iOS' or platform_system == 'Android') or python_version < '3.14')",
+    "lru_dict; not (platform_system == 'iOS' or platform_system == 'Android') or python_version < '3.14')",
+    "pillow; not (platform_system == 'iOS' or platform_system == 'Android') or python_version < '3.14')",
     # Numpy/pandas aren't available for iOS on 3.13+, or at all on 3.14.
     "numpy; python_version < '3.13' or (platform_system != 'iOS' and python_version < '3.14')",
     "pandas; python_version < '3.13' or (platform_system != 'iOS' and python_version < '3.14')",


### PR DESCRIPTION
A continuation of #103 - adds exclusions for the other binary modules, which won't be aren't available for 3.14.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
