### PR TITLE
Add pauses and log repeats to avoid issues with detecting test completion on iOS/macOS.

### DIFF
--- a/tests/testbed.py
+++ b/tests/testbed.py
@@ -1,5 +1,7 @@
 import os
+import sys
 import tempfile
+import time
 from pathlib import Path
 
 import pytest
@@ -23,10 +25,30 @@ def run_tests():
         ]
     )
 
-    print(f">>>>>>>>>> EXIT {returncode} <<<<<<<<<<")
+    # On iOS and macOS, Briefcase needs to use a log streamer. However, this
+    # streamer can drop lines of test output due to system load. If the log
+    # result sentinel isn't seen in streamed output, the test will fail because
+    # the exit status of the test isn't known. As a safety measure on iOS and
+    # macOS, output the log sentinel multiple times to decrease the chance of
+    # this happening.
+    if sys.platform in {"darwin", "ios"}:
+        for i in range(0, 6):
+            time.sleep(0.5)
+            print(f">>>>>>>>>> EXIT {returncode} <<<<<<<<<<")
+    else:
+        print(f">>>>>>>>>> EXIT {returncode} <<<<<<<<<<")
 
 
 if __name__ == "__main__":
+    # On iOS and macOS, Briefcase needs to use a log streamer. However, this
+    # streamer takes time to start up. As a safety measure, wait a couple of seconds
+    # at app start, and output some lines to minimize the impact of the streamer
+    # startup.
+    if sys.platform in {"darwin", "ios"}:
+        print("Waiting for log streamer...")
+        time.sleep(2.0)
+        print("Log streamer should be ready.")
+
     # Run the app main to stimulate app creation and logging of test conditions.
     app_main()
     # Run the actual test suite.


### PR DESCRIPTION
On macOS and iOS, add a short pause on test startup, and repeat the output of log results at the end of the test.

The log streamer takes time to start, and can drop some lines of output; this will result in a test run that was otherwise successful to fail simply because the "test was successful" marker wasn't seen.

This is particularly problematic on pre-release Pythons, as there are no binary modules, and so the test suite runs *really* fast - it has often finished before the log streamer starts streaming output.

This mirrors a change made on the Toga testbed. The startup delay isn't needed there because the Toga testbed takes minutes to run, and missing the first couple of lines out output isn't critical.

A better fix would be something like beeware/briefcase#2157 - but this is an immediate workaround for test unreliability when running the testbed.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
