### PR TITLE
Use more explicit rules for every platform, and use requirement_installer_args

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,22 +19,41 @@ sources = ["src/testbed"]
 test_sources = ["tests"]
 
 requires = [
-    # Skip binary dependencies on mobile for Python 3.14
-    "cryptography; (platform_system != 'iOS' and platform_system != 'Android') or python_version < '3.14'",
-    "lru_dict; (platform_system != 'iOS' and platform_system != 'Android') or python_version < '3.14'",
-    "pillow; (platform_system != 'iOS' and platform_system != 'Android') or python_version < '3.14'",
-    # Numpy/pandas aren't available for iOS on 3.13+, or at all on 3.14.
-    "numpy; python_version < '3.13' or (platform_system != 'iOS' and python_version < '3.14')",
-    "pandas; python_version < '3.13' or (platform_system != 'iOS' and python_version < '3.14')",
+    # Cryptography provides an ABI3 wheel for all desktop platforms, but requires cffi which doesn't.
+    """cryptography; \
+        (platform_system != 'iOS' and platform_system != 'Android' and python_version < '3.14') \
+        or (platform_system == 'iOS' and python_version < '3.14') \
+        or (platform_system == 'Android' and python_version < '3.14')""",
+    # lru_dict not available anywhere on 3.14
+    """lru_dict; \
+        (platform_system != 'iOS' and platform_system != 'Android' and python_version < '3.14') \
+        or (platform_system == 'iOS' and python_version < '3.14') \
+        or (platform_system == 'Android' and python_version < '3.14')""",
+    # pillow not available anywhere on 3.14
+    """pillow; \
+        (platform_system != 'iOS' and platform_system != 'Android' and python_version < '3.14') \
+        or (platform_system == 'iOS' and python_version < '3.14') \
+        or (platform_system == 'Android' and python_version < '3.14')""",
+    # Numpy not available on iOS for 3.13+, or all on 3.14.
+    """numpy; \
+        (platform_system != 'iOS' and platform_system != 'Android' and python_version < '3.14') \
+        or (platform_system == 'iOS' and python_version < '3.13') \
+        or (platform_system == 'Android' and python_version < '3.14')""",
+    # Pandas not available on iOS for 3.13+, or all on 3.14.
+    """pandas; \
+        (platform_system != 'iOS' and platform_system != 'Android' and python_version < '3.14') \
+        or (platform_system == 'iOS' and python_version < '3.13') \
+        or (platform_system == 'Android' and python_version < '3.14')""",
 ]
 test_requires = [
     "pytest",
 ]
-
+requirement_installer_args = [
+    "-f", "./wheels"
+]
 [tool.briefcase.app.testbed.macOS]
 requires = [
     # Provide a source of binary wheels that aren't provided on PyPI.
-    "--find-links", "./wheels",
     "rubicon-objc",
     "std-nslog",
 ]


### PR DESCRIPTION
* Move to using `requirement_installer_args` to reference local wheels
* Use more explicit rules for defining dependencies. These are much more verbose, and involve repetition between platforms, but it's a lot easier to reason about where wheels will/won't be installed. For example, the current rules will *always* install cryptography/lru_dict/pillow dependencies on desktop platforms, because they fall into the "not iOS, not Android" clause, which is *or* included with the Python3.14 clause.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
