### PR TITLE
Add pyspamsum to the acceptance test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,13 @@ requires = [
         or (platform_system == 'iOS' and python_version < '3.14') \
         or (platform_system == 'Android' and python_version < '3.14')""",
     # pyspamum has 3.13 wheels on iOS and Android; and no wheels on Windows
+    # On Linux, we need to restrict the test to Python3.13+, because Android reports
+    # as "Linux" on Python3.12 and earlier.
     """pyspamsum; \
-        (platform_system != 'iOS' and platform_system != 'Android' and platform_system != "Windows" and python_version < '3.14') \
+        (platform_system == 'Darwin' and python_version < '3.14') \
         or (platform_system == 'iOS' and python_version == '3.13') \
-        or (platform_system == 'Android' and python_version == '3.13')""",
+        or (platform_system == 'Android' and python_version == '3.13') \
+        or (platform_system == 'Linux' and python_version == '3.13')""",
     # Numpy not available on iOS for 3.13+, or all on 3.14.
     """numpy; \
         (platform_system != 'iOS' and platform_system != 'Android' and python_version < '3.14') \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,11 @@ requires = [
         (platform_system != 'iOS' and platform_system != 'Android' and python_version < '3.14') \
         or (platform_system == 'iOS' and python_version < '3.14') \
         or (platform_system == 'Android' and python_version < '3.14')""",
+    # pyspamum has 3.13 wheels on iOS and Android; and no wheels on Windows
+    """pyspamsum; \
+        (platform_system != 'iOS' and platform_system != 'Android' and platform_system != "Windows" and python_version < '3.14') \
+        or (platform_system == 'iOS' and python_version == '3.13') \
+        or (platform_system == 'Android' and python_version == '3.13')""",
     # Numpy not available on iOS for 3.13+, or all on 3.14.
     """numpy; \
         (platform_system != 'iOS' and platform_system != 'Android' and python_version < '3.14') \

--- a/tests/test_thirdparty.py
+++ b/tests/test_thirdparty.py
@@ -117,6 +117,22 @@ def test_cryptography():
     assert "www.android.com" == domain
 
 
+@xfail_if_not_installed("pyspamsum")
+def test_pyspamsum():
+    "The PySpamSum binary module can be used"
+    # spamsum is a binary module, with iOS/Android binary wheels published on
+    # PyPI.
+    import spamsum
+
+    assert (
+        spamsum.spamsum(
+            "I am the very model of a modern Major-General, "
+            "I've information animal and vegetable and mineral"
+        )
+        == "3:kEvyc/sFIKwYclQY4MKLFE4Igu0uLzIKygn:kE6Ai3KQ/MKOgDKZn"
+    )
+
+
 @xfail_if_not_installed("lru-dict")
 def test_lru_dict():
     "The LRUDict binary module can be used"


### PR DESCRIPTION
PySpamSum is a binary package that has been published to PyPI, so it's a useful test of iOS/Android packaging.

Wheels are only available for Python 3.13+, and aren't available on Windows.

We need to exclude the install of pyspamsum on Linux 3.12 and earlier because it collides with the platform identification on Android.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
