### PR TITLE
Add a test of .pth handling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 .idea
 *.dist-info/
+*.egg-info/
 build/
 logs/
 .DS_Store

--- a/pth-tester/pth_tester.py
+++ b/pth-tester/pth_tester.py
@@ -1,0 +1,8 @@
+initialized = False
+
+
+# The pth_tester module should be initalized by processing the `.pth` file
+# created on installation.
+def init():
+    global initialized
+    initialized = True

--- a/pth-tester/pyproject.toml
+++ b/pth-tester/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["setuptools==78.0.2", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "x-pth-tester"
+version = "1.0.0"
+classifiers = ["Private :: Do Not Upload"]

--- a/pth-tester/setup.py
+++ b/pth-tester/setup.py
@@ -1,0 +1,44 @@
+import os
+
+import setuptools
+from setuptools.command.install import install
+
+
+# Copied from setuptools:
+# (https://github.com/pypa/setuptools/blob/7c859e017368360ba66c8cc591279d8964c031bc/setup.py#L40C6-L82)
+class install_with_pth(install):
+    """
+    Custom install command to install a .pth file.
+
+    This hack is necessary because there's no standard way to install behavior
+    on startup (and it's debatable if there should be one). This hack (ab)uses
+    the `extra_path` behavior in Setuptools to install a `.pth` file with
+    implicit behavior on startup.
+
+    The original source strongly recommends against using this behavior.
+    """
+
+    _pth_name = "_pth_tester"
+    _pth_contents = "import pth_tester; pth_tester.init()"
+
+    def initialize_options(self):
+        install.initialize_options(self)
+        self.extra_path = self._pth_name, self._pth_contents
+
+    def finalize_options(self):
+        install.finalize_options(self)
+        self._restore_install_lib()
+
+    def _restore_install_lib(self):
+        """
+        Undo secondary effect of `extra_path` adding to `install_lib`
+        """
+        suffix = os.path.relpath(self.install_lib, self.install_libbase)
+
+        if suffix.strip() == self._pth_contents.strip():
+            self.install_lib = self.install_libbase
+
+
+setuptools.setup(
+    cmdclass={"install": install_with_pth},
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,12 @@ sources = ["src/testbed"]
 test_sources = ["tests"]
 
 requires = [
+    # Android can't process .pth files (see chaquo/chaquopy#1338). This also
+    # means we can only test Linux on Python3.13+, because Android reports as
+    # "Linux" on Python3.12 and earlier.
+    """./pth-tester; \
+        (platform_system != 'Linux' and platform_system != 'Android') \
+        or (platform_system == 'Linux' and python_version >= '3.13')""",
     # Cryptography provides an ABI3 wheel for all desktop platforms, but requires cffi which doesn't.
     """cryptography; \
         (platform_system != 'iOS' and platform_system != 'Android' and python_version < '3.14') \

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -7,6 +7,8 @@ import sys
 
 import pytest
 
+from .test_thirdparty import xfail_if_not_installed
+
 
 def test_bootstrap_modules():
     "All the bootstrap modules are importable"
@@ -444,3 +446,13 @@ def test_zoneinfo():
 
     dt = datetime(2022, 5, 4, 13, 40, 42, tzinfo=ZoneInfo("Australia/Perth"))
     assert str(dt) == "2022-05-04 13:40:42+08:00"
+
+
+@xfail_if_not_installed("x-pth-tester")
+def test_pth_handling():
+    ".pth files installed by a package are processed"
+    import pth_tester
+
+    # The pth_tester module should be "initialized" as a result of
+    # processing the .pth file created when the package is installed.
+    assert pth_tester.initialized


### PR DESCRIPTION
Add a test that `.pth` files are processed.

This is done by adding an in-repo test project that can be installed; that project creates a `.pth` file when it is installed, which invokes an `init()` method. That method sets a flag on the module which the test can then assert.

Draws heavily from @timrid's timrid/pth-execution-checker project.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
