### PR TITLE
Numpy now available for iOS on Python 3.13.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,12 @@ requires = [
         or (platform_system == 'iOS' and python_version == '3.13') \
         or (platform_system == 'Android' and python_version == '3.13') \
         or (platform_system == 'Linux' and python_version == '3.13')""",
-    # Numpy not available on iOS for 3.13+, or all on 3.14.
+    # Numpy not available on 3.14+.
     """numpy; \
         (platform_system != 'iOS' and platform_system != 'Android' and python_version < '3.14') \
-        or (platform_system == 'iOS' and python_version < '3.13') \
+        or (platform_system == 'iOS' and python_version < '3.14') \
         or (platform_system == 'Android' and python_version < '3.14')""",
-    # Pandas not available on iOS for 3.13+, or all on 3.14.
+    # Pandas not available on iOS for 3.13+, or all on 3.14+.
     """pandas; \
         (platform_system != 'iOS' and platform_system != 'Android' and python_version < '3.14') \
         or (platform_system == 'iOS' and python_version < '3.13') \


### PR DESCRIPTION
Back when 3.13 was released, I punted on published numpy 3.13 wheels; since some parts of the PyCon tutorial use numpy, I've gone back and filled that gap. 

Pandas is still a problem because 1.5.3 uses a private PyLong API in C code that has been removed in 3.13, and newer Pandas builds use meson, so there's other configuration issues to resolve.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
