### PR TITLE
Bump docformatter from v1.7.7 to v1.7.8-rc1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.7
+    rev: v1.7.8-rc1
     hooks:
       - id: docformatter
         args: [--in-place, --black]


### PR DESCRIPTION
Bumps `pre-commit` hook for `docformatter` from v1.7.7 to v1.7.8-rc1 and ran the update against the repo.