### PR TITLE
Revert docformatter to 1.7.7.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           - backend: iOS
             runs-on: macos-latest
             briefcase-target: "iOS"
-            briefcase-run-args: ' -d "iPhone SE (3rd generation)"'
+            briefcase-run-args: ' -d "iPhone SE (3rd generation):iOS 18.5"'
 
           - backend: android
             runs-on: ubuntu-latest
@@ -123,6 +123,16 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
+
+    - name: Prepare macOS
+      # GitHub recommends explicitly selecting the desired Xcode version:
+      # https://github.com/actions/runner-images/issues/12541#issuecomment-3083850140
+      # This became a necessity as a result of
+      # https://github.com/actions/runner-images/issues/12541 and
+      # https://github.com/actions/runner-images/issues/12751.
+      if: matrix.runs-on == 'macos-latest'
+      run: |
+        sudo xcode-select --switch /Applications/Xcode_16.5.app
 
     - name: Install Dependencies
       run: ${{ matrix.pre-command }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           - backend: iOS
             runs-on: macos-latest
             briefcase-target: "iOS"
-            briefcase-run-args: ' -d "iPhone SE (3rd generation):iOS 18.5"'
+            briefcase-run-args: ' -d "iPhone SE (3rd generation)::iOS 18.5"'
 
           - backend: android
             runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
       # https://github.com/actions/runner-images/issues/12751.
       if: matrix.runs-on == 'macos-latest'
       run: |
-        sudo xcode-select --switch /Applications/Xcode_16.5.app
+        sudo xcode-select --switch /Applications/Xcode_16.4.app
 
     - name: Install Dependencies
       run: ${{ matrix.pre-command }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.8-rc1
+    rev: v1.7.7
     hooks:
       - id: docformatter
         args: [--in-place, --black]


### PR DESCRIPTION
Docformatter appears to have memoryholed their 1.7.8-rc1 release (presumably due to the many catastrophic issues with it).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
