### PR TITLE
Bump ruff-pre-commit from v0.12.10 to v0.12.11

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: docformatter
         args: [--in-place, --black]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.10
+    rev: v0.12.11
     hooks:
       - id: ruff-format
       - id: ruff-check


### PR DESCRIPTION
Bumps `pre-commit` hook for `ruff-pre-commit` from v0.12.10 to v0.12.11 and ran the update against the repo.