### PR TITLE
Bump docformatter from v1.7.7 to v1.7.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.7
+    rev: v1.7.8
     hooks:
       - id: docformatter
         args: [--in-place, --black]

--- a/pth-tester/setup.py
+++ b/pth-tester/setup.py
@@ -9,10 +9,10 @@ from setuptools.command.install import install
 class install_with_pth(install):
     """Custom install command to install a .pth file.
 
-    This hack is necessary because there's no standard way to install behavior
-    on startup (and it's debatable if there should be one). This hack (ab)uses
-    the `extra_path` behavior in Setuptools to install a `.pth` file with
-    implicit behavior on startup.
+    This hack is necessary because there's no standard way to install behavior on
+    startup (and it's debatable if there should be one). This hack (ab)uses the
+    `extra_path` behavior in Setuptools to install a `.pth` file with implicit behavior
+    on startup.
 
     The original source strongly recommends against using this behavior.
     """


### PR DESCRIPTION
Bumps `pre-commit` hook for `docformatter` from v1.7.7 to v1.7.8 and ran the update against the repo.