### PR TITLE
Add a temporary pin to std-nslog to allow support packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,10 @@
 # Python Support Testbed
 
-This is a testbed application that can be used to do basic verification checks
-of the support package builds used by BeeWare (Python-Apple-support and
-Python-Android-support). It is not a comprehensive Python unit test suite; it
-checks modules that have a history of being misconfigured or broken in builds.
+This is a testbed application that can be used to do basic verification checks of the support package builds used by BeeWare (Python-Apple-support and Python-Android-support). It is not a comprehensive Python unit test suite; it checks modules that have a history of being misconfigured or broken in builds.
 
-The app can be deployed with Briefcase. When executed, the app will generate
-output on the console log that is similar to a unit test suite. If it returns 0
-test failures, you can have some confidence that the support build is
-functioning as expected.
+The app can be deployed with Briefcase. When executed, the app will generate output on the console log that is similar to a unit test suite. If it returns 0 test failures, you can have some confidence that the support build is functioning as expected.
 
-Before running, ensure that the template and support package paths point at the
-builds you want to test. The paths committed in the repo assume that you have a
-directory layout that looks something like:
+Before running, ensure that the template and support package paths point at the builds you want to test. The paths committed in the repo assume that you have a directory layout that looks something like:
 
 - (your projects folder)
   - support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ requirement_installer_args = [
 requires = [
     # Provide a source of binary wheels that aren't provided on PyPI.
     "rubicon-objc",
-    "std-nslog",
+    "std-nslog~=1.0.3",
 ]
 # support_package = "../Python-Apple-support/dist/Python-3.14-macOS-support.custom.tar.gz"
 
@@ -118,7 +118,6 @@ requires = [
 [tool.briefcase.app.testbed.iOS]
 requires = [
     "rubicon-objc",
-    "std-nslog",
 ]
 min_os_version = "17.0"
 # support_package = "../Python-Apple-support/dist/Python-3.14-iOS-support.custom.tar.gz"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ project_name = "Testbed"
 bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
-license.file = "LICENSE"
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 author = 'Russell Keith-Magee'
 author_email = "russell@beeware.org"
 
@@ -118,6 +119,7 @@ requires = [
 [tool.briefcase.app.testbed.iOS]
 requires = [
     "rubicon-objc",
+    "std-nslog~=1.0.3",
 ]
 min_os_version = "17.0"
 # support_package = "../Python-Apple-support/dist/Python-3.14-iOS-support.custom.tar.gz"


### PR DESCRIPTION
The release of std-nslog 2.0.0 requires changes in the macOS template before it can be used; it's correctly pinned in all the templates, but *not* in this test project.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
