### PR TITLE
Update template to use macOS-26 logging.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,7 @@ jobs:
           - "windows-app"
           - "iOS"
           - "android"
-        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        exclude:
-          # Android doesn't have 3.14 support packages yet
-          - python-version: "3.14"
-            backend: "android"
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
         include:
           - runs-on: ubuntu-latest
@@ -112,44 +108,44 @@ jobs:
               sudo udevadm trigger --name-match=kvm
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6.0.3
-      with:
-        fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 0
 
-    - name: Set up Python
-      uses: actions/setup-python@v6.2.0
-      if: matrix.python-version != 'system'
-      with:
-        python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        if: matrix.python-version != 'system'
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
-    - name: Prepare macOS
-      # GitHub recommends explicitly selecting the desired Xcode version:
-      # https://github.com/actions/runner-images/issues/12541#issuecomment-3083850140
-      # This became a necessity as a result of
-      # https://github.com/actions/runner-images/issues/12541 and
-      # https://github.com/actions/runner-images/issues/12751.
-      if: matrix.runs-on == 'macos-latest'
-      run: |
-        sudo xcode-select --switch /Applications/Xcode_16.4.app
+      - name: Prepare macOS
+        # GitHub recommends explicitly selecting the desired Xcode version:
+        # https://github.com/actions/runner-images/issues/12541#issuecomment-3083850140
+        # This became a necessity as a result of
+        # https://github.com/actions/runner-images/issues/12541 and
+        # https://github.com/actions/runner-images/issues/12751.
+        if: matrix.runs-on == 'macos-latest'
+        run: |
+          sudo xcode-select --switch /Applications/Xcode_16.4.app
 
-    - name: Install Dependencies
-      run: ${{ matrix.pre-command }}
+      - name: Install Dependencies
+        run: ${{ matrix.pre-command }}
 
-    - name: Install Briefcase
-      uses: beeware/.github/.github/actions/install-briefcase@main
+      - name: Install Briefcase
+        uses: beeware/.github/.github/actions/install-briefcase@main
 
-    - name: Test App
-      timeout-minutes: 15
-      run: briefcase run ${{ matrix.briefcase-target }} --test ${{ matrix.briefcase-run-args }}
+      - name: Test App
+        timeout-minutes: 15
+        run: briefcase run ${{ matrix.briefcase-target }} --test ${{ matrix.briefcase-run-args }}
 
-    - name: Package
-      run: briefcase package ${{ matrix.briefcase-target }} --update --adhoc-sign
+      - name: Package
+        run: briefcase package ${{ matrix.briefcase-target }} --update --adhoc-sign
 
-    - name: Upload Logs
-      uses: actions/upload-artifact@v7.0.1
-      if: failure()
-      with:
-        name: build-failure-logs-${{ matrix.backend }}-${{ matrix.python-version }}
-        path: logs/*
+      - name: Upload Logs
+        uses: actions/upload-artifact@v7.0.1
+        if: failure()
+        with:
+          name: build-failure-logs-${{ matrix.backend }}-${{ matrix.python-version }}
+          path: logs/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ requirement_installer_args = [
 requires = [
     # Provide a source of binary wheels that aren't provided on PyPI.
     "rubicon-objc",
-    "std-nslog~=1.0.3",
+    "std-nslog~=2.0.0",
 ]
 # support_package = "../Python-Apple-support/dist/Python-3.14-macOS-support.custom.tar.gz"
 
@@ -119,7 +119,6 @@ requires = [
 [tool.briefcase.app.testbed.iOS]
 requires = [
     "rubicon-objc",
-    "std-nslog~=1.0.3",
 ]
 min_os_version = "17.0"
 # support_package = "../Python-Apple-support/dist/Python-3.14-iOS-support.custom.tar.gz"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,14 @@ requires = [
     "x-pth-tester",
 
     # Cryptography provides an ABI3 wheel for all desktop platforms and iOS.
-    """cryptography; \
+    # Crptography 49 doesn't publish x86-64 or universal macOS wheels.
+    """cryptography < 49.0; \
         (platform_system != 'Android' and python_version < '3.15') \
         or (platform_system == 'Android' and python_version < '3.14')""",
     # lru_dict available everywhere
-    "lru_dict; python_version < '3.15'",
+    """lru_dict; \
+        (platform_system != 'Android' and python_version < '3.15') \
+        or (platform_system == 'Android' and python_version < '3.14')""",
     # pillow not available anywhere on 3.15, or on Android for 3.14+.
     """pillow; \
         (platform_system != 'Android' and python_version < '3.15') \


### PR DESCRIPTION
Updates the testbed project to use macOS-26-compatible `os_log`-based logging.

Also adds Android tests for Python 3.14 (which were initially disabled, but can now be run).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
