### PR TITLE
Disable the use of a skin on Android test runs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
             runs-on: ubuntu-latest
             briefcase-target: "android"
             briefcase-run-args: >
-              --device '{"avd":"beePhone"}'
+              --device '{"avd":"beePhone","device_type":"pixel"}'
               --Xemulator=-no-window
               --Xemulator=-no-snapshot
               --Xemulator=-no-audio


### PR DESCRIPTION
beeware/briefcase#2788 added the ability to create an Android emulator with no skin by specifying a device type but no skin  type; this change was made to Toga in beeware/toga#4316, but the equivalent change was never made here.

This is needed because Google puts a fairly heavy rate limit on skin downloads, so if there's a bunch of Android CI jobs started at once (as often happens on first-of-the-month Dependabot runs), the CI jobs fail because of skin downloads, not because of an actual problem.

The skin is entirely cosmetic; it doesn't alter CI operation.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
